### PR TITLE
Multiples of 3 or 5

### DIFF
--- a/Katas/multiples/index.js
+++ b/Katas/multiples/index.js
@@ -1,0 +1,8 @@
+const solution = (number) => {
+  if (number < 0) return 0;
+  let arr = [];
+  for (let i = 1; i < number; i++) {
+    i % 3 === 0 || i % 5 === 0 ? arr.push(i) : null;
+  }
+  return arr.length > 0 ? arr.reduce((acc, curr) => acc + curr) : 0;
+};


### PR DESCRIPTION
If we list all the natural numbers below 10 that are multiples of 3 or 5, we get 3, 5, 6 and 9. The sum of these multiples is 23.

Finish the solution so that it returns the sum of all the multiples of 3 or 5 below the number passed in. Additionally, if the number is negative, return 0 (for languages that do have them).

Note: If the number is a multiple of both 3 and 5, only count it once.
