### PR TITLE
Regex validate PIN code

### DIFF
--- a/Katas/pin-code/index.js
+++ b/Katas/pin-code/index.js
@@ -1,0 +1,5 @@
+const validatePIN = (pin) => {
+    const reg4Digit = /^\d{4}$/s
+    const reg6Digit = /^\d{6}$/s
+    return reg4Digit.test(pin) || reg6Digit.test(pin) ? true : false 
+  }


### PR DESCRIPTION
ATM machines allow 4 or 6 digit PIN codes and PIN codes cannot contain anything but exactly 4 digits or exactly 6 digits.

If the function is passed a valid PIN string, return true, else return false.

Examples (Input --> Output)

```
"1234"   -->  true
"12345"  -->  false
"a234"   -->  false
```