### PR TITLE
Vowel Count

### DIFF
--- a/Katas/vowel-count/index.js
+++ b/Katas/vowel-count/index.js
@@ -1,0 +1,14 @@
+const getCount = (str) => {
+ 
+    const vowels = ['a', 'e', 'i', 'o', 'u']
+    let vowelsCount = 0
+    const letters = [...str]
+    
+    letters.forEach(letter => {
+      vowels.forEach(vowel => {
+        letter === vowel ? vowelsCount++ : null
+      })
+    })
+   
+    return vowelsCount;
+  }


### PR DESCRIPTION
Return the number (count) of vowels in the given string.

We will consider `a`, `e`, `I`, `o`, `u` as vowels for this Kata (but not `y`).

The input string will only consist of lower case letters and/or spaces.