### PR TITLE
Which are in?

### DIFF
--- a/Katas/which-are-in/index.js
+++ b/Katas/which-are-in/index.js
@@ -1,0 +1,12 @@
+const inArray = (array1, array2) => {
+  let arrOfSequence = [];
+
+  array2.forEach((word) => {
+    array1.forEach((seq) => {
+      if (word.match(seq) !== null) {
+        arrOfSequence.push(seq);
+      }
+    });
+  });
+  return [...new Set(arrOfSequence.sort())];
+};


### PR DESCRIPTION
Given two arrays of strings `a1` and `a2` return a sorted array `r` in lexicographical order of the strings of `a1` which are substrings of strings of `a2`.

Example 1:
```
a1 = ["arp", "live", "strong"]
a2 = ["lively", "alive", "harp", "sharp", "armstrong"]
```
returns `["arp", "live", "strong"]`

Example 2:
```
a1 = ["tarp", "mice", "bull"]
a2 = ["lively", "alive", "harp", "sharp", "armstrong"]
```

returns `[]` 

Notes:

Arrays are written in "general" notation. See "Your Test Cases" for examples in your language.
In Shell bash `a1` and `a2` are strings. The return is a string where words are separated by commas.
Beware: `r` must be without duplicates.