### PR TITLE
Filter unused digits

### DIFF
--- a/Katas/filter-unused-digits/index.js
+++ b/Katas/filter-unused-digits/index.js
@@ -1,0 +1,15 @@
+const unusedDigits = (...array) => {
+  const inputNumbersToArray = Array.from(String(array), (n) =>
+    Number(n) !== NaN ? Number(n) : ""
+  ).filter((n) => n !== "");
+
+  const numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  let absentNumbers = "";
+  numbers.forEach((number) => {
+    if (!inputNumbersToArray.includes(number)) {
+      absentNumbers += String(number);
+    }
+  });
+
+  return absentNumbers;
+};


### PR DESCRIPTION
Given a varying number of integer arguments, return the digits that are not present in any of them.

Example:

```
[12, 34, 56, 78]  =>  "09"
[2015, 8, 26]     =>  "3479"
``` 
Note: the digits in the resulting string should be sorted.