### PR TITLE
chmod calculator in octal

### DIFF
--- a/Katas/chmod-calculator/index.js
+++ b/Katas/chmod-calculator/index.js
@@ -1,25 +1,25 @@
 const chmodCalculator = (perm) => {
   const regexArr = [/rwx/, /r-x/, /r--/, /---/, /--x/, /rw-/, /-wx/, /-w-/];
-  const octals = ["7", "5", "4", "0", "1", "6", "3", "2"];
+  const octal = ["7", "5", "4", "0", "1", "6", "3", "2"];
   let octalArray = [];
   perm.user === undefined
     ? octalArray.push(0)
     : regexArr.forEach((regex, index) =>
-        perm.user.match(regex) ? octalArray.push(octals[index]) : null
+        perm.user.match(regex) ? octalArray.push(octal[index]) : null
       );
   perm.group === undefined
     ? octalArray.push(0)
     : regexArr.forEach((regex, index) =>
-        perm.group.match(regex) ? octalArray.push(octals[index]) : null
+        perm.group.match(regex) ? octalArray.push(octal[index]) : null
       );
   perm.other === undefined
     ? octalArray.push(0)
     : regexArr.forEach((regex, index) =>
-        perm.other.match(regex) ? octalArray.push(octals[index]) : null
+        perm.other.match(regex) ? octalArray.push(octal[index]) : null
       );
 
-  let displayOctals = "";
-  return octalArray.map((digit) => (displayOctals += digit))[2];
+  let displayOctal = "";
+  return octalArray.map((digit) => (displayOctal += digit))[2];
 };
 
 module.exports = chmodCalculator;

--- a/Katas/chmod-calculator/index.js
+++ b/Katas/chmod-calculator/index.js
@@ -1,0 +1,26 @@
+const chmodCalculator = (perm) => {
+  console.log(perm);
+  const regexArr = [/rwx/, /r-x/, /r--/, /---/, /--x/, /rw-/, /-wx/, /-w-/];
+  const octals = ["7", "5", "4", "0", "1", "6", "3", "2"];
+  let octalArray = [];
+  perm.user === undefined
+    ? octalArray.push(0)
+    : regexArr.forEach((regex, index) =>
+        perm.user.match(regex) ? octalArray.push(octals[index]) : null
+      );
+  perm.group === undefined
+    ? octalArray.push(0)
+    : regexArr.forEach((regex, index) =>
+        perm.group.match(regex) ? octalArray.push(octals[index]) : null
+      );
+  perm.other === undefined
+    ? octalArray.push(0)
+    : regexArr.forEach((regex, index) =>
+        perm.other.match(regex) ? octalArray.push(octals[index]) : null
+      );
+
+  let displayOctals = "";
+  return octalArray.map((digit) => (displayOctals += digit))[2];
+};
+
+module.exports = chmodCalculator;

--- a/Katas/chmod-calculator/index.js
+++ b/Katas/chmod-calculator/index.js
@@ -1,5 +1,4 @@
 const chmodCalculator = (perm) => {
-  console.log(perm);
   const regexArr = [/rwx/, /r-x/, /r--/, /---/, /--x/, /rw-/, /-wx/, /-w-/];
   const octals = ["7", "5", "4", "0", "1", "6", "3", "2"];
   let octalArray = [];

--- a/Katas/chmod-calculator/index.test.js
+++ b/Katas/chmod-calculator/index.test.js
@@ -1,0 +1,15 @@
+const chmodCalculator = require("./index.js");
+test("test", () => {
+  expect(chmodCalculator({ user: 'rwx', group: 'r-x', other: 'r-x' })).toBe('755');
+  expect(chmodCalculator({ user: 'rwx', group: 'r--', other: 'r--' })).toBe('744');
+  expect(chmodCalculator({ user: 'r-x', group: 'r-x', other: 'r-x' })).toBe('555');
+  expect(chmodCalculator({ group: 'rwx' })).toBe('070');
+  expect(chmodCalculator({})).toBe('000');
+  expect(chmodCalculator({ other: 'rw-' })).toBe('006');
+  expect(chmodCalculator({ user: 'rwx', group: 'r--', other: '--x' })).toBe('741');
+  expect(chmodCalculator({ user: '--x', other: 'r--' })).toBe('104');
+  expect(chmodCalculator({ user: '-w-' })).toBe('200');
+  expect(chmodCalculator({ other: '---' })).toBe('000');
+  expect(chmodCalculator({ user: 'r--', group: '-w-', other: 'r--' })).toBe('424');
+  expect(chmodCalculator({ group: '-w-' })).toBe('020');
+});


### PR DESCRIPTION
Lot of junior developer can be stuck when they need to change the access permission to a file or a directory in an Unix-like operating systems.

To do that they can use the `chmod` command and with some magic trick they can change the permissionof a file or a directory. For more information about the `chmod` command you can take a look at the [wikipedia page](https://en.wikipedia.org/wiki/Chmod).

`chmod` provides two types of syntax that can be used for changing permissions. An absolute form using octal to denote which permissions bits are set e.g: 766. Your goal in this kata is to define the octal you need to use in order to set yout permission correctly.

Here is the list of the permission you can set with the octal representation of this one.

User
read (4)
write (2)
execute (1)
Group
read (4)
write (2)
execute (1)
Other
read (4)
write (2)
execute (1)
The method take a hash in argument this one can have a maximum of 3 keys (`owner`,`group`,`other`). Each key will have a 3 chars string to represent the permission, for example the string `rw-` say that the user want the permission `read`, `write` without the `execute`. If a key is missing set the permission to `---`

Note: `chmod` allow you to set some special flags too (`setuid`, `setgid`, sticky bit) but to keep some simplicity for this kata we will ignore this one.