### PR TITLE
Odd-heavy Array

### DIFF
--- a/Katas/odd-heavy/index.js
+++ b/Katas/odd-heavy/index.js
@@ -1,0 +1,24 @@
+const isOddHeavy = (n) => {
+    const even = n.filter((n) => n % 2 === 0);
+    const odd = n.filter((n) => n % 2 !== 0);
+    if (odd.length === 0) return false;
+    if (even.length === 0) return true;
+  
+    const highestEven = even.reduce((acc, curr) => {
+      if (acc < curr) {
+        return (acc = curr);
+      } else {
+        return acc;
+      }
+    });
+    const lowestOdd = odd.reduce((acc, curr) => {
+      if (acc > curr) {
+        return (acc = curr);
+      } else {
+        return acc;
+      }
+    });
+    return lowestOdd > highestEven;
+  };
+  
+module.exports = isOddHeavy

--- a/Katas/odd-heavy/index.test.js
+++ b/Katas/odd-heavy/index.test.js
@@ -1,0 +1,16 @@
+const isOddHeavy = require("./index.js");
+test("test", () => {
+  expect(isOddHeavy([0,2,19,4,4])).toBe(true);
+  expect(isOddHeavy([1,-2,-1,2])).toBe(false);
+  expect(isOddHeavy([ 6, 2, 4, 2, 2, 2, 1, 5, 0, -100 ])).toBe(false);
+  expect(isOddHeavy([ 3, 2, 10, 4, 1, 6, 9 ])).toBe(false);
+  expect(isOddHeavy([ 9, 0, 6 ])).toBe(true);
+  expect(isOddHeavy([ 2, 2, 3, 3, 3 ])).toBe(true);
+  expect(isOddHeavy([ -1, 1, -1, 2, 1, -1, 1, -2 ])).toBe(false);
+  expect(isOddHeavy([ 1, 1, 15, -1, -1 ])).toBe(true);
+  expect(isOddHeavy([ -1, -2, 21 ])).toBe(true);
+  expect(isOddHeavy([ 1, -1, 3, -1 ])).toBe(true);
+  expect(isOddHeavy([ -2, -4, -6, -8, -11 ])).toBe(false);
+  expect(isOddHeavy([ 3 ])).toBe(true);
+  expect(isOddHeavy([ 0, 2, 3 ])).toBe(true);
+});


### PR DESCRIPTION
An array is defined to be `odd-heavy` if it contains at least one `odd` element and every element whose value is odd is greater than every even-valued element.
```
Array [11,4,9,2,8] is odd-heavy 
because:- its odd elements [11,9] are greater than all the even elements [4,2,8]

Array [11,4,9,2,3,10] is not odd-heavy
because:- one of it's even element 10 from [4,2,10] is greater than two of its odd elements [9,3] from [ 11,9,3]
```
write a function called `isOddHeavy` or `is_odd_heavy` that accepts an integer array and returns `true` if the array is odd-heavy else return `false`.