### PR TITLE
CamelCase Method

### DIFF
--- a/Katas/camelcase-method/index.js
+++ b/Katas/camelcase-method/index.js
@@ -1,5 +1,5 @@
 const log = console.log
-String.prototype.camelCase = () =>{
+String.prototype.camelCase = function(){
   log(this)
     // Initialize an empty string to store the final output
   let camelCased = ''

--- a/Katas/camelcase-method/index.js
+++ b/Katas/camelcase-method/index.js
@@ -1,12 +1,12 @@
 const log = console.log
-String.prototype.camelCase = function(){
-  log(this)
+function camelCase(string){
+  log(string)
     // Initialize an empty string to store the final output
   let camelCased = ''
     // Check if the input string is empty, if so return it
-  if(this === "") return this
+  if(string === "") return string
     // split the string with spaces, filter out any empty elements 
-  this.split(' ').filter(el => el !== '').forEach(word => {
+  string.split(' ').filter(el => el !== '').forEach(word => {
     let capitalized = ''
     //iterate through the words and split them into letters
     word.split('').forEach((letter, index) => {
@@ -20,4 +20,4 @@ String.prototype.camelCase = function(){
   return camelCased
 }
 
-module.exports = String.prototype.camelCase
+module.exports = camelCase

--- a/Katas/camelcase-method/index.js
+++ b/Katas/camelcase-method/index.js
@@ -1,0 +1,23 @@
+const log = console.log
+String.prototype.camelCase = () =>{
+  log(this)
+    // Initialize an empty string to store the final output
+  let camelCased = ''
+    // Check if the input string is empty, if so return it
+  if(this === "") return this
+    // split the string with spaces, filter out any empty elements 
+  this.split(' ').filter(el => el !== '').forEach(word => {
+    let capitalized = ''
+    //iterate through the words and split them into letters
+    word.split('').forEach((letter, index) => {
+      // check if the index of the letter is 0 and if so, convert it to uppercase
+      index === 0 ? capitalized+= letter.toUpperCase() : capitalized+= letter
+    })
+    camelCased+= capitalized
+  })
+  //return the final camelCased string
+  log(camelCased)
+  return camelCased
+}
+
+module.exports = String.prototype.camelCase

--- a/Katas/camelcase-method/index.test.js
+++ b/Katas/camelcase-method/index.test.js
@@ -1,0 +1,12 @@
+const duplicateEncode = require("./index.js");
+test("test", () => {
+  expect(duplicateEncode('test case')).toBe("TestCase");
+  expect(duplicateEncode("camel case method")).toBe("CamelCaseMethod");
+  expect(duplicateEncode("say hello ")).toBe("SayHello");
+  expect(duplicateEncode(' camel case word')).toBe("CamelCaseWord");
+  expect(duplicateEncode('hrdqxmbntdq wcrrgparkfm evlofkcjwvqhju omxw dzacfgfcrobe beysbg')).toBe("HrdqxmbntdqWcrrgparkfmEvlofkcjwvqhjuOmxwDzacfgfcrobeBeysbg");
+  expect(duplicateEncode('jbtbyibifryi ljeppwewmtgn')).toBe("JbtbyibifryiLjeppwewmtgn");
+  expect(duplicateEncode('zxfxdlbcxs bnkqzsifxhrz chlbgwx cfpuhvvimg')).toBe("ZxfxdlbcxsBnkqzsifxhrzChlbgwxCfpuhvvimg");
+  expect(duplicateEncode('pbg bcekwgyvmljtt ynilfctbfkfx ikthv qzsjpfwxk sjsmzxhfgooqkc duofirkttqduxxy rjuaa qfyjnrngcisrmvp dypzetixxnz')).toBe("PbgBcekwgyvmljttYnilfctbfkfxIkthvQzsjpfwxkSjsmzxhfgooqkcDuofirkttqduxxyRjuaaQfyjnrngcisrmvpDypzetixxnz");
+  expect(duplicateEncode('vlaxdqvf zpaq fxvyorkmxtil kfxblcjjapygus akukbtotx vwwmdbblpraaq enkjwuftedijoam')).toBe("VlaxdqvfZpaqFxvyorkmxtilKfxblcjjapygusAkukbtotxVwwmdbblpraaqEnkjwuftedijoam");
+});

--- a/Katas/camelcase-method/index.test.js
+++ b/Katas/camelcase-method/index.test.js
@@ -1,12 +1,12 @@
-const duplicateEncode = require("./index.js");
+const camelCase = require("./index.js");
 test("test", () => {
-  expect(duplicateEncode('test case')).toBe("TestCase");
-  expect(duplicateEncode("camel case method")).toBe("CamelCaseMethod");
-  expect(duplicateEncode("say hello ")).toBe("SayHello");
-  expect(duplicateEncode(' camel case word')).toBe("CamelCaseWord");
-  expect(duplicateEncode('hrdqxmbntdq wcrrgparkfm evlofkcjwvqhju omxw dzacfgfcrobe beysbg')).toBe("HrdqxmbntdqWcrrgparkfmEvlofkcjwvqhjuOmxwDzacfgfcrobeBeysbg");
-  expect(duplicateEncode('jbtbyibifryi ljeppwewmtgn')).toBe("JbtbyibifryiLjeppwewmtgn");
-  expect(duplicateEncode('zxfxdlbcxs bnkqzsifxhrz chlbgwx cfpuhvvimg')).toBe("ZxfxdlbcxsBnkqzsifxhrzChlbgwxCfpuhvvimg");
-  expect(duplicateEncode('pbg bcekwgyvmljtt ynilfctbfkfx ikthv qzsjpfwxk sjsmzxhfgooqkc duofirkttqduxxy rjuaa qfyjnrngcisrmvp dypzetixxnz')).toBe("PbgBcekwgyvmljttYnilfctbfkfxIkthvQzsjpfwxkSjsmzxhfgooqkcDuofirkttqduxxyRjuaaQfyjnrngcisrmvpDypzetixxnz");
-  expect(duplicateEncode('vlaxdqvf zpaq fxvyorkmxtil kfxblcjjapygus akukbtotx vwwmdbblpraaq enkjwuftedijoam')).toBe("VlaxdqvfZpaqFxvyorkmxtilKfxblcjjapygusAkukbtotxVwwmdbblpraaqEnkjwuftedijoam");
+  expect(camelCase('test case')).toBe("TestCase");
+  expect(camelCase("camel case method")).toBe("CamelCaseMethod");
+  expect(camelCase("say hello ")).toBe("SayHello");
+  expect(camelCase(' camel case word')).toBe("CamelCaseWord");
+  expect(camelCase('hrdqxmbntdq wcrrgparkfm evlofkcjwvqhju omxw dzacfgfcrobe beysbg')).toBe("HrdqxmbntdqWcrrgparkfmEvlofkcjwvqhjuOmxwDzacfgfcrobeBeysbg");
+  expect(camelCase('jbtbyibifryi ljeppwewmtgn')).toBe("JbtbyibifryiLjeppwewmtgn");
+  expect(camelCase('zxfxdlbcxs bnkqzsifxhrz chlbgwx cfpuhvvimg')).toBe("ZxfxdlbcxsBnkqzsifxhrzChlbgwxCfpuhvvimg");
+  expect(camelCase('pbg bcekwgyvmljtt ynilfctbfkfx ikthv qzsjpfwxk sjsmzxhfgooqkc duofirkttqduxxy rjuaa qfyjnrngcisrmvp dypzetixxnz')).toBe("PbgBcekwgyvmljttYnilfctbfkfxIkthvQzsjpfwxkSjsmzxhfgooqkcDuofirkttqduxxyRjuaaQfyjnrngcisrmvpDypzetixxnz");
+  expect(camelCase('vlaxdqvf zpaq fxvyorkmxtil kfxblcjjapygus akukbtotx vwwmdbblpraaq enkjwuftedijoam')).toBe("VlaxdqvfZpaqFxvyorkmxtilKfxblcjjapygusAkukbtotxVwwmdbblpraaqEnkjwuftedijoam");
 });


### PR DESCRIPTION
Write simple .camelCase method (camel_case function in PHP, CamelCase in C# or camelCase in Java) for strings. All words must have their first letter capitalized without spaces.

For instance:

```
"hello case".camelCase() => HelloCase
"camel case word".camelCase() => CamelCaseWord
``