### PR TITLE
Simple Interest and Compound Interest

### DIFF
--- a/Katas/compound-interest/index.js
+++ b/Katas/compound-interest/index.js
@@ -1,5 +1,4 @@
 function interest(P, r, n) {
-  console.log(P, r, n);
   let withInterest = P + P * r;
   let base = 0;
   for (let i = 2; i <= n; i++) {
@@ -11,7 +10,6 @@ function interest(P, r, n) {
     }
   }
   if (n === 0) return [Math.round(P + P * r * n), Math.round(P + P * r * n)];
-  console.log([Math.round(P + P * r * n), Math.round(withInterest)]);
   return [Math.round(P + P * r * n), Math.round(withInterest)];
 }
 

--- a/Katas/compound-interest/index.js
+++ b/Katas/compound-interest/index.js
@@ -1,14 +1,10 @@
 function interest(P, r, n) {
-  let withInterest = P + P * r;
-  let base = 0;
+  let withInterest = P + P * r; 
+  let base = 0; 
   for (let i = 2; i <= n; i++) {
-    if (i === 0) {
-      continue;
-    } else {
-      base = withInterest * r;
+      base = withInterest * r; 
       withInterest += base;
     }
-  }
   if (n === 0) return [Math.round(P + P * r * n), Math.round(P + P * r * n)];
   return [Math.round(P + P * r * n), Math.round(withInterest)];
 }

--- a/Katas/compound-interest/index.js
+++ b/Katas/compound-interest/index.js
@@ -1,0 +1,18 @@
+function interest(P, r, n) {
+  console.log(P, r, n);
+  let withInterest = P + P * r;
+  let base = 0;
+  for (let i = 2; i <= n; i++) {
+    if (i === 0) {
+      continue;
+    } else {
+      base = withInterest * r;
+      withInterest += base;
+    }
+  }
+  if (n === 0) return [Math.round(P + P * r * n), Math.round(P + P * r * n)];
+  console.log([Math.round(P + P * r * n), Math.round(withInterest)]);
+  return [Math.round(P + P * r * n), Math.round(withInterest)];
+}
+
+module.exports = interest;

--- a/Katas/compound-interest/index.test.js
+++ b/Katas/compound-interest/index.test.js
@@ -1,0 +1,12 @@
+const interest = require("./index.js");
+test("test", () => {
+  expect(interest(100, 0.1, 1)).toBe([110, 110]);
+  expect(interest(100, 0.1, 2)).toBe([120, 121]);
+  expect(interest(100, 0.1, 10)).toBe([200, 259]);
+  expect(interest(7505, 0.3760540808126702, 33)).toBe([100640, 282047518]);
+  expect(interest(6716, 0.2051344611382686, 2)).toBe([9471, 9754]);
+  expect(interest(4443, 0.4145371629721235, 45)).toBe([87323, 26627021838]);
+  expect(interest(7518, 0.32602903795839344, 18)).toBe([51638, 1207972]);
+  expect(interest(1850, 0.42180835235166336, 18)).toBe([15896, 1043064]);
+  expect(interest(3485, 0.7492510382163715, 41)).toBe([110542, 31560257405522]);
+});

--- a/Katas/compound-interest/index.test.js
+++ b/Katas/compound-interest/index.test.js
@@ -1,12 +1,12 @@
 const interest = require("./index.js");
 test("test", () => {
-  expect(interest(100, 0.1, 1)).toBe([110, 110]);
-  expect(interest(100, 0.1, 2)).toBe([120, 121]);
-  expect(interest(100, 0.1, 10)).toBe([200, 259]);
-  expect(interest(7505, 0.3760540808126702, 33)).toBe([100640, 282047518]);
-  expect(interest(6716, 0.2051344611382686, 2)).toBe([9471, 9754]);
-  expect(interest(4443, 0.4145371629721235, 45)).toBe([87323, 26627021838]);
-  expect(interest(7518, 0.32602903795839344, 18)).toBe([51638, 1207972]);
-  expect(interest(1850, 0.42180835235166336, 18)).toBe([15896, 1043064]);
-  expect(interest(3485, 0.7492510382163715, 41)).toBe([110542, 31560257405522]);
+  expect(interest(100, 0.1, 1)).toStrictEqual([110, 110]);
+  expect(interest(100, 0.1, 2)).toStrictEqual([120, 121]);
+  expect(interest(100, 0.1, 10)).toStrictEqual([200, 259]);
+  expect(interest(7505, 0.3760540808126702, 33)).toStrictEqual([100640, 282047518]);
+  expect(interest(6716, 0.2051344611382686, 2)).toStrictEqual([9471, 9754]);
+  expect(interest(4443, 0.4145371629721235, 45)).toStrictEqual([87323, 26627021838]);
+  expect(interest(7518, 0.32602903795839344, 18)).toStrictEqual([51638, 1207972]);
+  expect(interest(1850, 0.42180835235166336, 18)).toStrictEqual([15896, 1043064]);
+  expect(interest(3485, 0.7492510382163715, 41)).toStrictEqual([110542, 31560257405522]);
 });


### PR DESCRIPTION
Simple interest on a loan is calculated by simply taking the initial amount (the principal, p) and multiplying it by a rate of interest (r) and the number of time periods (n).

Compound interest is calculated by adding the interest after each time period to the amount owed, then calculating the next interest payment based on the principal PLUS the interest from all previous periods.

Given a principal p, interest rate r, and a number of periods n, return an array [ total owed under simple interest, total owed under compound interest ]

Notes:

Round all answers to the nearest integer
Principal will always be an integer between 0 and 9999
interest rate will be a decimal between 0 and 1
number of time periods will be an integer between 0 and 50
Examples

```
interest(100, 0.1,  1)  =  [110, 110]
interest(100, 0.1,  2)  =  [120, 121]
interest(100, 0.1, 10)  =  [200, 259]
```