### PR TITLE
PaginationHelper

### DIFF
--- a/Katas/paginationhelper/index.js
+++ b/Katas/paginationhelper/index.js
@@ -1,0 +1,57 @@
+// The constructor takes in an array of items and a integer indicating how many
+// items fit within a single page
+
+function PaginationHelper(collection, itemsPerPage){
+  this.collection = collection;
+  this.itemsPerPage = itemsPerPage
+}
+
+// returns the number of items within the entire collection
+PaginationHelper.prototype.itemCount = function() {
+  return this.collection.length
+}
+
+// returns the number of pages
+PaginationHelper.prototype.pageCount = function() {
+  return Math.ceil(this.collection.length / this.itemsPerPage)
+}
+
+// returns the number of items on the current page. page_index is zero based.
+// this method should return -1 for pageIndex values that are out of range
+PaginationHelper.prototype.pageItemCount = function(pageIndex) {
+  const howManyPages = Math.ceil(this.collection.length / this.itemsPerPage) 
+  if(pageIndex + 1 > howManyPages || pageIndex < 0){
+    return -1
+  } else if(pageIndex + 1 < howManyPages){
+    return this.itemsPerPage
+  } else {
+    let counter = 0
+    for(let i = 0; i < howManyPages - 1; i++){
+      counter+= this.itemsPerPage
+    } 
+    return this.collection.slice(counter).length
+  }
+}
+
+// determines what page an item is on. Zero based indexes
+// this method should return -1 for itemIndex values that are out of range
+PaginationHelper.prototype.pageIndex = function(itemIndex) {
+  if(itemIndex >= this.collection.length || itemIndex < 0 || this.collection.length === 0) return -1
+  if(itemIndex === 0) return 0
+  if(itemIndex === this.itemsPerPage) return 1
+  if(this.itemsPerPage === 1) return itemIndex
+  const howManyPages = Math.ceil(this.collection.length / this.itemsPerPage)
+  for(let i = 1; i <= itemIndex; i++){
+    if(itemIndex === this.itemsPerPage * i){
+      return i
+    }
+  }
+  let counter1 = 0
+  let counter2 = 0
+  for(let i = 0; i <= howManyPages; i++){
+    counter1+= this.itemsPerPage
+    counter2++
+    if(counter1 >= itemIndex) break
+  }
+  return counter2 - 1
+}

--- a/Katas/paginationhelper/index.js
+++ b/Katas/paginationhelper/index.js
@@ -19,39 +19,16 @@ PaginationHelper.prototype.pageCount = function() {
 // returns the number of items on the current page. page_index is zero based.
 // this method should return -1 for pageIndex values that are out of range
 PaginationHelper.prototype.pageItemCount = function(pageIndex) {
-  const howManyPages = Math.ceil(this.collection.length / this.itemsPerPage) 
-  if(pageIndex + 1 > howManyPages || pageIndex < 0){
-    return -1
-  } else if(pageIndex + 1 < howManyPages){
-    return this.itemsPerPage
-  } else {
-    let counter = 0
-    for(let i = 0; i < howManyPages - 1; i++){
-      counter+= this.itemsPerPage
-    } 
-    return this.collection.slice(counter).length
-  }
+  const howManyPages = Math.floor(this.collection.length / this.itemsPerPage);
+  if (pageIndex < 0 || pageIndex >= Math.ceil(this.collection.length / this.itemsPerPage)) return -1;
+  if (pageIndex < howManyPages) return this.itemsPerPage;
+  return this.collection.length % this.itemsPerPage;
 }
+
 
 // determines what page an item is on. Zero based indexes
 // this method should return -1 for itemIndex values that are out of range
 PaginationHelper.prototype.pageIndex = function(itemIndex) {
-  if(itemIndex >= this.collection.length || itemIndex < 0 || this.collection.length === 0) return -1
-  if(itemIndex === 0) return 0
-  if(itemIndex === this.itemsPerPage) return 1
-  if(this.itemsPerPage === 1) return itemIndex
-  const howManyPages = Math.ceil(this.collection.length / this.itemsPerPage)
-  for(let i = 1; i <= itemIndex; i++){
-    if(itemIndex === this.itemsPerPage * i){
-      return i
-    }
-  }
-  let counter1 = 0
-  let counter2 = 0
-  for(let i = 0; i <= howManyPages; i++){
-    counter1+= this.itemsPerPage
-    counter2++
-    if(counter1 >= itemIndex) break
-  }
-  return counter2 - 1
+  if (itemIndex < 0 || itemIndex >= this.collection.length) return -1;
+  return Math.floor(itemIndex / this.itemsPerPage);
 }


### PR DESCRIPTION
For this exercise you will be strengthening your page-fu mastery. You will complete the PaginationHelper class, which is a utility class helpful for querying paging information related to an array.

The class is designed to take in an array of values and an integer indicating how many items will be allowed per each page. The types of values contained within the collection/array are not relevant.

The following are some examples of how this class is used:

```
var helper = new PaginationHelper(['a','b','c','d','e','f'], 4);
helper.pageCount(); //should == 2
helper.itemCount(); //should == 6
helper.pageItemCount(0); //should == 4
helper.pageItemCount(1); // last page - should == 2
helper.pageItemCount(2); // should == -1 since the page is invalid

// pageIndex takes an item index and returns the page that it belongs on
helper.pageIndex(5); //should == 1 (zero based index)
helper.pageIndex(2); //should == 0
helper.pageIndex(20); //should == -1
helper.pageIndex(-10); //should == -1
```